### PR TITLE
Fix handler return value

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/icelab/draft-js-block-breakout-plugin",
   "peerDependencies": {
-    "draft-js": ">=0.7.0",
+    "draft-js": ">=0.9.0",
     "react": ">=15.0.0",
     "react-dom": ">=15.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -114,11 +114,11 @@ export default function blockBreakoutPlugin (options = {}) {
             setEditorState(
               EditorState.push(editorState, newContentState, 'split-block')
             )
-            return true
+            return 'handled'
           }
         }
       }
-      return false
+      return 'not-handled'
     },
   }
 }


### PR DESCRIPTION
Hi, Please check this.

I think should return value to `'handled'` or `'not-handled'` in `handleReturn`  .

refs:

- https://github.com/draft-js-plugins/draft-js-plugins/pull/499#issuecomment-255530058
- https://github.com/draft-js-plugins/draft-js-plugins/blob/master/draft-js-plugins-editor/src/Editor/index.js#L144
- https://github.com/facebook/draft-js/blob/b4afd3c6aa5dd7203362beff3d1b020738a69cf6/docs/APIReference-Editor.md#cancelable-handlers-optional
- https://github.com/facebook/draft-js/commit/b4afd3c6aa5dd7203362beff3d1b020738a69cf6

Maybe this issue https://github.com/icelab/draft-js-block-breakout-plugin/issues/3
