### PR TITLE
Fix block length getter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,7 @@ export default function blockBreakoutPlugin (options = {}) {
           const contentState = editorState.getCurrentContent()
           const currentBlock = contentState.getBlockForKey(selection.getEndKey())
           const endOffset = selection.getEndOffset()
-          const atEndOfBlock = (endOffset === currentBlock.getCharacterList().count())
+          const atEndOfBlock = (endOffset === currentBlock.getLength())
           const atStartOfBlock = (endOffset === 0)
 
           // Check we’re at the start/end of the current block


### PR DESCRIPTION
Hi,

There is a method to get the length of the block.

ref: https://facebook.github.io/draft-js/docs/api-reference-content-block.html#getlength

I think this is more appropriate, more safety.
