### PR TITLE
Fix immutable.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "tape": "4.5.1"
   },
   "dependencies": {
-    "immutable": "^3.8.1"
+    "immutable": "~3.7.4"
   }
 }


### PR DESCRIPTION
Hi,

I think that version of `immutable` should be the same as `draft-js` and `draft-js-plugins` .

ref: 

- https://github.com/facebook/draft-js/blob/master/package.json#L34
- https://github.com/draft-js-plugins/draft-js-plugins/blob/master/draft-js-plugins-editor/package.json#L34
