### PR TITLE
Fix bug with handleReturn with latest version of draft-js-plugins

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,9 +3,6 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
-
 exports.default = blockBreakoutPlugin;
 
 var _draftJs = require('draft-js');
@@ -38,18 +35,16 @@ var defaults = {
  * @return {Object} Object defining the draft-js API methods
  */
 function blockBreakoutPlugin() {
-  var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+  var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
 
   var breakoutBlockType = options.breakoutBlockType || defaults.breakoutBlockType;
   var breakoutBlocks = options.breakoutBlocks || defaults.breakoutBlocks;
   var doubleBreakoutBlocks = options.doubleBreakoutBlocks || defaults.doubleBreakoutBlocks;
 
   return {
-    handleReturn: function handleReturn(e, _ref) {
-      var getEditorState = _ref.getEditorState;
+    handleReturn: function handleReturn(e, editorState, _ref) {
       var setEditorState = _ref.setEditorState;
 
-      var editorState = getEditorState();
       var currentBlockType = _draftJs.RichUtils.getCurrentBlockType(editorState);
       var isSingleBreakoutBlock = breakoutBlocks.indexOf(currentBlockType) > -1;
       var isDoubleBreakoutBlock = doubleBreakoutBlocks.indexOf(currentBlockType) > -1;
@@ -60,73 +55,67 @@ function blockBreakoutPlugin() {
 
         // Check if the selection is collapsed
         if (selection.isCollapsed()) {
-          var _ret = function () {
-            var contentState = editorState.getCurrentContent();
-            var currentBlock = contentState.getBlockForKey(selection.getEndKey());
-            var endOffset = selection.getEndOffset();
-            var atEndOfBlock = endOffset === currentBlock.getLength();
-            var atStartOfBlock = endOffset === 0;
+          var contentState = editorState.getCurrentContent();
+          var currentBlock = contentState.getBlockForKey(selection.getEndKey());
+          var endOffset = selection.getEndOffset();
+          var atEndOfBlock = endOffset === currentBlock.getLength();
+          var atStartOfBlock = endOffset === 0;
 
-            // Check we’re at the start/end of the current block
-            if (atEndOfBlock && isSingleBreakoutBlock || atStartOfBlock && isSingleBreakoutBlock || atStartOfBlock && !currentBlock.getLength()) {
-              var emptyBlockKey = (0, _draftJs.genKey)();
-              var emptyBlock = new _draftJs.ContentBlock({
-                key: emptyBlockKey,
-                text: '',
-                type: breakoutBlockType,
-                characterList: (0, _immutable.List)(),
-                depth: 0
-              });
-              var blockMap = contentState.getBlockMap();
-              // Split the blocks
-              var blocksBefore = blockMap.toSeq().takeUntil(function (v) {
-                return v === currentBlock;
-              });
+          // Check we’re at the start/end of the current block
+          if (atEndOfBlock && isSingleBreakoutBlock || atStartOfBlock && isSingleBreakoutBlock || atStartOfBlock && !currentBlock.getLength()) {
+            var emptyBlockKey = (0, _draftJs.genKey)();
+            var emptyBlock = new _draftJs.ContentBlock({
+              key: emptyBlockKey,
+              text: '',
+              type: breakoutBlockType,
+              characterList: (0, _immutable.List)(),
+              depth: 0
+            });
+            var blockMap = contentState.getBlockMap();
+            // Split the blocks
+            var blocksBefore = blockMap.toSeq().takeUntil(function (v) {
+              return v === currentBlock;
+            });
 
-              var blocksAfter = blockMap.toSeq().skipUntil(function (v) {
-                return v === currentBlock;
-              }).rest();
+            var blocksAfter = blockMap.toSeq().skipUntil(function (v) {
+              return v === currentBlock;
+            }).rest();
 
-              var augmentedBlocks = void 0;
-              var focusKey = void 0;
-              // Choose which order to apply the augmented blocks in depending
-              // on whether we’re at the start or the end
-              if (atEndOfBlock) {
-                if (isDoubleBreakoutBlock) {
-                  // Discard Current as it was blank
-                  augmentedBlocks = [[emptyBlockKey, emptyBlock]];
-                } else {
-                  // Current first, empty block afterwards
-                  augmentedBlocks = [[currentBlock.getKey(), currentBlock], [emptyBlockKey, emptyBlock]];
-                }
-                focusKey = emptyBlockKey;
+            var augmentedBlocks = void 0;
+            var focusKey = void 0;
+            // Choose which order to apply the augmented blocks in depending
+            // on whether we’re at the start or the end
+            if (atEndOfBlock) {
+              if (isDoubleBreakoutBlock) {
+                // Discard Current as it was blank
+                augmentedBlocks = [[emptyBlockKey, emptyBlock]];
               } else {
-                // Empty first, current block afterwards
-                augmentedBlocks = [[emptyBlockKey, emptyBlock], [currentBlock.getKey(), currentBlock]];
-                focusKey = currentBlock.getKey();
+                // Current first, empty block afterwards
+                augmentedBlocks = [[currentBlock.getKey(), currentBlock], [emptyBlockKey, emptyBlock]];
               }
-              // Join back together with the current + new block
-              var newBlocks = blocksBefore.concat(augmentedBlocks, blocksAfter).toOrderedMap();
-              var newContentState = contentState.merge({
-                blockMap: newBlocks,
-                selectionBefore: selection,
-                selectionAfter: selection.merge({
-                  anchorKey: focusKey,
-                  anchorOffset: 0,
-                  focusKey: focusKey,
-                  focusOffset: 0,
-                  isBackward: false
-                })
-              });
-              // Set the state
-              setEditorState(_draftJs.EditorState.push(editorState, newContentState, 'split-block'));
-              return {
-                v: 'handled'
-              };
+              focusKey = emptyBlockKey;
+            } else {
+              // Empty first, current block afterwards
+              augmentedBlocks = [[emptyBlockKey, emptyBlock], [currentBlock.getKey(), currentBlock]];
+              focusKey = currentBlock.getKey();
             }
-          }();
-
-          if ((typeof _ret === 'undefined' ? 'undefined' : _typeof(_ret)) === "object") return _ret.v;
+            // Join back together with the current + new block
+            var newBlocks = blocksBefore.concat(augmentedBlocks, blocksAfter).toOrderedMap();
+            var newContentState = contentState.merge({
+              blockMap: newBlocks,
+              selectionBefore: selection,
+              selectionAfter: selection.merge({
+                anchorKey: focusKey,
+                anchorOffset: 0,
+                focusKey: focusKey,
+                focusOffset: 0,
+                isBackward: false
+              })
+            });
+            // Set the state
+            setEditorState(_draftJs.EditorState.push(editorState, newContentState, 'split-block'));
+            return 'handled';
+          }
         }
       }
       return 'not-handled';

--- a/src/index.js
+++ b/src/index.js
@@ -49,8 +49,7 @@ export default function blockBreakoutPlugin (options = {}) {
   const doubleBreakoutBlocks = options.doubleBreakoutBlocks || defaults.doubleBreakoutBlocks
 
   return {
-    handleReturn (e, { getEditorState, setEditorState }) {
-      const editorState = getEditorState()
+    handleReturn (e, editorState, { setEditorState }) {
       const currentBlockType = RichUtils.getCurrentBlockType(editorState)
       const isSingleBreakoutBlock = breakoutBlocks.indexOf(currentBlockType) > -1
       const isDoubleBreakoutBlock = doubleBreakoutBlocks.indexOf(currentBlockType) > -1


### PR DESCRIPTION
Looks like the arguments being passed got modified slightly.

Should fix https://github.com/icelab/draft-js-block-breakout-plugin/issues/12

Also, I ran `npm run build` and `lib/index.js` looks quite different 🤔 Not sure why, this should just be based off latest master. Maybe a build wasn't run after a previous change or something?